### PR TITLE
Fix 15 verified review findings: deploy pipeline, accessibility, iOS, dead links

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -27,13 +27,13 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -67,11 +67,11 @@ jobs:
           # Remove this line if you would like to skip using google analytics
           REACT_APP_GA_TRACKING_ID: UA-68649021-1
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "build"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -32,21 +32,17 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        node-version: [20.x, 22.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
           - os: windows-latest
-            node-version: 16.x
-          - os: windows-latest
-            node-version: 18.x
+            node-version: 22.x
           - os: macos-latest
-            node-version: 16.x
-          - os: macos-latest
-            node-version: 18.x
+            node-version: 22.x
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "analyze": "npm run build && source-map-explorer build/static/js/*.chunk.js",
     "build": "rimraf ./build && react-scripts build",
+    "postbuild": "node -e \"require('fs').copyFileSync('build/index.html','build/404.html')\"",
     "lint": "eslint \"**/*.js\"",
     "start": "react-scripts start",
     "test": "npx jest",

--- a/src/components/Contact/EmailLink.js
+++ b/src/components/Contact/EmailLink.js
@@ -80,7 +80,7 @@ const EmailLink = ({ loopMessage }) => {
       onMouseEnter={() => setIsActive(false)}
       onMouseLeave={() => idx < messages.length && setIsActive(true)}
     >
-      <a href={validateText(message) ? 'mailto:colinlof@udel.edu' : ''}>
+      <a href="mailto:colinlof@udel.edu">
         <span>{message}</span>
         <span>colinlof@udel.edu</span>
       </a>

--- a/src/components/Resume/Skills/CategoryButton.js
+++ b/src/components/Resume/Skills/CategoryButton.js
@@ -5,6 +5,7 @@ const CategoryButton = ({ handleClick, active, label }) => (
   <button
     className={`skillbutton ${active[label] ? 'skillbutton-active' : ''}`}
     type="button"
+    aria-pressed={!!active[label]}
     onClick={() => handleClick(label)}
   >
     {label}

--- a/src/components/Template/Hamburger.js
+++ b/src/components/Template/Hamburger.js
@@ -8,19 +8,42 @@ const Menu = lazy(() => import('react-burger-menu/lib/menus/slide'));
 const Hamburger = () => {
   const [open, setOpen] = useState(false);
 
+  const toggleKeyDown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      setOpen(!open);
+    }
+  };
+
   return (
     <div className="hamburger-container">
       <nav className="main" id="hambuger-nav">
         <ul>
           {open ? (
             <li className="menu close-menu">
-              <div onClick={() => setOpen(!open)} className="menu-hover">
+              <div
+                onClick={() => setOpen(!open)}
+                onKeyDown={toggleKeyDown}
+                role="button"
+                tabIndex={0}
+                aria-label="Close menu"
+                aria-expanded
+                className="menu-hover"
+              >
                 &#10005;
               </div>
             </li>
           ) : (
             <li className="menu open-menu">
-              <div onClick={() => setOpen(!open)} className="menu-hover">
+              <div
+                onClick={() => setOpen(!open)}
+                onKeyDown={toggleKeyDown}
+                role="button"
+                tabIndex={0}
+                aria-label="Open menu"
+                aria-expanded={false}
+                className="menu-hover"
+              >
                 &#9776;
               </div>
             </li>

--- a/src/pages/Stats.js
+++ b/src/pages/Stats.js
@@ -5,7 +5,7 @@ import Main from '../layouts/Main';
 const Stats = () => (
   <Main
     title="Research / Publications"
-    description="Explore my undergraduate research and published work in machine learning, finance, and space systems."
+    description="Research and published work on social media sentiment and financial markets."
   >
     <article className="post" id="research">
       <header>
@@ -13,10 +13,7 @@ const Stats = () => (
           <h2>
             <Link to="/stats">Research & Publications</Link>
           </h2>
-          <p>
-            A showcase of my technical research experience and scholarly
-            contributions
-          </p>
+          <p>Research I have contributed to and published work</p>
         </div>
       </header>
       <h3>📄 Publications</h3>

--- a/src/static/css/base/_page.scss
+++ b/src/static/css/base/_page.scss
@@ -44,12 +44,22 @@ body {
   *,
   *::before,
   *::after {
+    animation-delay: 0ms !important;
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    transition-delay: 0ms !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
 
+  .will-reveal {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+
+// Print / save-as-PDF must never inherit the pre-reveal hidden state.
+@media print {
   .will-reveal {
     opacity: 1 !important;
     transform: none !important;

--- a/src/static/css/base/_typography.scss
+++ b/src/static/css/base/_typography.scss
@@ -45,17 +45,24 @@ textarea {
 }
 
 a {
-  background-image: linear-gradient(currentColor, currentColor);
+  // A resting underline keeps links distinguishable without relying on
+  // color alone (accent blue and body gray have near-equal luminance).
+  background-image: linear-gradient(
+    rgba(0, 83, 159, 0.35),
+    rgba(0, 83, 159, 0.35)
+  );
   background-position: 0 92%;
   background-repeat: no-repeat;
-  background-size: 0% 1px;
+  background-size: 100% 1px;
   color: _palette(accent);
   text-decoration: none;
   transition: color #{_duration(transition)} $ease-out-soft,
-    background-size #{_duration(transition)} $ease-out-soft;
+    background-size #{_duration(transition)} $ease-out-soft,
+    background-image #{_duration(transition)} $ease-out-soft;
 
   &:hover {
-    background-size: 100% 1px;
+    background-image: linear-gradient(currentColor, currentColor);
+    background-size: 100% 2px;
     color: _palette(accent-hover);
   }
 }

--- a/src/static/css/components/_button.scss
+++ b/src/static/css/components/_button.scss
@@ -35,7 +35,17 @@ button,
     transform #{_duration(transition)} $ease-out-soft;
   white-space: nowrap;
 
-  &:hover,
+  // :hover gated so iOS sticky-hover cannot fake button state; kept as a
+  // separate rule from :focus-visible because Safari <= 15.3 drops any
+  // selector list containing an unsupported selector.
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: _palette(accent);
+      box-shadow: inset 0 0 0 1px _palette(accent);
+      color: #ffffff !important;
+    }
+  }
+
   &:focus-visible {
     background-color: _palette(accent);
     box-shadow: inset 0 0 0 1px _palette(accent);

--- a/src/static/css/layout/_header.scss
+++ b/src/static/css/layout/_header.scss
@@ -128,7 +128,12 @@ body {
             transition: transform #{_duration(transition)} $ease-out-soft;
           }
 
-          &:hover::after,
+          @media (hover: hover) and (pointer: fine) {
+            &:hover::after {
+              transform: scaleX(1);
+            }
+          }
+
           &:focus-visible::after {
             transform: scaleX(1);
           }
@@ -280,13 +285,13 @@ body {
 
 .open-menu {
   position: fixed;
-  right: 0;
+  right: env(safe-area-inset-right);
   border: none;
 }
 
 .close-menu {
   position: fixed;
-  right: 0;
+  right: env(safe-area-inset-right);
   z-index: 3;
   border-left: 0;
 }

--- a/src/static/css/libs/_vars.scss
+++ b/src/static/css/libs/_vars.scss
@@ -57,7 +57,7 @@ $palette: (
   bg-alt: #faf9f7,
   fg: #57534e,
   fg-bold: #1c1917,
-  fg-light: #a29d97,
+  fg-light: #78716c,
   border: rgba(28, 25, 23, 0.12),
   border-bg: rgba(28, 25, 23, 0.045),
   border-alt: rgba(28, 25, 23, 0.28),

--- a/src/static/css/pages/_resume.scss
+++ b/src/static/css/pages/_resume.scss
@@ -4,6 +4,7 @@
   .link-to {
     position: relative;
     top: -4.5em;
+    top: calc(-4.5em - env(safe-area-inset-top));
   }
 
   .link-container h4 {

--- a/src/static/css/pages/_skills.scss
+++ b/src/static/css/pages/_skills.scss
@@ -16,10 +16,16 @@
   outline: none;
 }
 
-.skillbutton-active {
+.skillbutton.skillbutton-active {
   background-color: _palette(accent-tint);
   box-shadow: inset 0 0 0 1px _palette(accent);
   color: _palette(accent) !important;
+}
+
+// Selected text on the dark bar fills stays readable.
+.skillbar ::selection {
+  background: rgba(255, 255, 255, 0.95);
+  color: #1c1917;
 }
 
 .skillbar {

--- a/src/static/css/pages/_stats.scss
+++ b/src/static/css/pages/_stats.scss
@@ -7,8 +7,10 @@
     tbody tr {
       transition: background-color 0.15s $ease-out-soft;
 
-      &:hover {
-        background-color: _palette(accent-tint);
+      @media (hover: hover) and (pointer: fine) {
+        &:hover {
+          background-color: _palette(accent-tint);
+        }
       }
 
       td:last-child {


### PR DESCRIPTION
## Summary

A 22-agent adversarial review (4 dimension reviewers, every finding independently verified against the code) confirmed 15 real defects. This PR fixes all of them.

### Deploy pipeline (why nothing has actually deployed today)
- Both workflows targeted the **retired `ubuntu-20.04` runner** and shut-down Pages action versions — Pages runs have been sitting queued/cancelled since April 2025. Moved to `ubuntu-latest`, `setup-node@v4`, `configure-pages@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`; CI matrix modernized to Node 20/22.
- Added a `postbuild` step that copies `index.html` → `404.html` so deep links to `/resume` etc. survive on GitHub Pages (react-snap is in devDeps but was never wired to a script).

### Accessibility
- `fg-light` meta-text token darkened to pass AA (was 2.69:1)
- Resting underlines restored on body links (accent blue vs body gray was 1.005:1 luminance — indistinguishable without color vision)
- Print/save-as-PDF no longer outputs blank scroll-reveal sections
- Reduced-motion now zeroes stagger delays; skill filters expose `aria-pressed`; burger toggle is keyboard-operable; readable `::selection` on dark bars

### iOS / WebKit
- Resume section anchors account for `env(safe-area-inset-top)` (titles landed under the taller notched-device header)
- Button/nav/table hovers gated behind `(hover: hover) and (pointer: fine)` — sticky tap-hover could previously fake the skill-filter active state
- `:hover` and `:focus-visible` split into separate rules (Safari ≤ 15.3 drops combined lists)
- Burger toggle respects `safe-area-inset-right` in landscape

### Content / correctness
- Contact page email CTA was a dead `href` that reloaded the page — now a real `mailto:`
- Research page description no longer claims ML/space-systems scope

## Verification
`npm run lint` clean · 7/7 jest tests · production build compiles · Playwright pass on desktop + iPhone 13 viewports (all pages, menu, filters, reveals, reduced-motion)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGfaGcchV7AEmJhxC5BCzb)_